### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,8 @@ Fastpath Plugin Changelog
 
 <p><b>4.5.1</b> -- tbd</p>
 <ul>
+    <li>Now requires Openfire 4.8.0 or later.</li>
+    <li>[<a href="https://github.com/igniterealtime/openfire-fastpath-plugin/issues/68">#68</a>] - Fix compatibility issue with Openfire 4.9.0.</li>
 </ul>
 
 <p><b>4.5.0</b> -- November 20, 2023</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,8 +6,8 @@
     <description>Support for managed queued chat requests, such as a support team might use.</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2023-11-20</date>
-    <minServerVersion>4.1.1</minServerVersion>
+    <date>2024-09-11</date>
+    <minServerVersion>4.8.0</minServerVersion>
     <databaseKey>fastpath</databaseKey>
     <databaseVersion>1</databaseVersion>
     

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.7.1</version>
+        <version>4.8.0</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>fastpath</artifactId>
@@ -20,8 +20,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                       <fork>true</fork>
                       <compilerArgument>-XDignore.symbol.file</compilerArgument>                    
                 </configuration>

--- a/src/java/org/jivesoftware/xmpp/workgroup/interceptor/UserInterceptor.java
+++ b/src/java/org/jivesoftware/xmpp/workgroup/interceptor/UserInterceptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2004-2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jivesoftware.xmpp.workgroup.interceptor;
 
 import org.jivesoftware.util.StringUtils;
@@ -17,11 +32,11 @@ public class UserInterceptor implements PacketInterceptor {
     /**
      * A Map of banned bare JIDs.
      */
-    private Map<String,String> jidBanMap = new HashMap<String,String>();
+    private Map<String,String> jidBanMap = new HashMap<>();
     /**
      * A Map of banned domains.
      */
-    private Map<String,String> domainBanMap = new HashMap<String,String>();
+    private Map<String,String> domainBanMap = new HashMap<>();
     private String fromEmail;
     private String fromName;
     private String emailSubject = "";
@@ -130,7 +145,7 @@ public class UserInterceptor implements PacketInterceptor {
             emailNotifyList = null;
         }
         else {
-            emailNotifyList = new ArrayList<String>();
+            emailNotifyList = new ArrayList<>();
             StringTokenizer tokenizer = new StringTokenizer(notifyList, ",");
             while (tokenizer.hasMoreTokens()) {
                 String emailAddress = tokenizer.nextToken().trim();
@@ -215,14 +230,14 @@ public class UserInterceptor implements PacketInterceptor {
             return;
         }
         for (String toEmail : emailNotifyList) {
-            body = StringUtils.replace(emailBody, "{packet}", packet.toXML());
-            body = StringUtils.replace(body, "{sender}", packetSender);
+            body = emailBody.replaceAll("\\{packet}", packet.toXML());
+            body = body.replaceAll("\\{sender}", packetSender);
             emailService.sendMessage(null, toEmail, fromName, fromEmail, emailSubject, body, null);
         }
     }
 
     private static Map<String,String> getMap(String iPStr) {
-        Map<String,String> newMap = new HashMap<String,String>();
+        Map<String,String> newMap = new HashMap<>();
         if (iPStr == null) {
             return newMap;
         }
@@ -236,7 +251,7 @@ public class UserInterceptor implements PacketInterceptor {
 
 
     private static String getString(Map<String,String> map) {
-        if (map == null || map.size() == 0) {
+        if (map == null || map.isEmpty()) {
             return "";
         }
         // Iterate through the elements in the map.

--- a/src/java/org/jivesoftware/xmpp/workgroup/search/ChatSearch.java
+++ b/src/java/org/jivesoftware/xmpp/workgroup/search/ChatSearch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2008 Jive Software. All rights reserved.
+ * Copyright (C) 2004-2008 Jive Software, 2024 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -334,9 +334,9 @@ public class ChatSearch {
     }
 
     private String stripWildcards(String string) {
-        string = StringUtils.replace(string, "*", "");
-        string = StringUtils.replace(string, "?", "");
-        string = StringUtils.replace(string, "~", "");
+        string = string.replaceAll("\\*", "");
+        string = string.replaceAll("\\?", "");
+        string = string.replaceAll("~", "");
         return string;
     }
 

--- a/src/web/agent-selectors.jsp
+++ b/src/web/agent-selectors.jsp
@@ -88,7 +88,7 @@
                 "<%= descriptor.getBeanClass().getName() %>",
                 "<%= descriptor.getValue("version") %>",
                 "<%= descriptor.getValue("author") %>",
-                "<%= StringUtils.replace(descriptor.getShortDescription(), "\"", "\\\"") %>"
+                "<%= descriptor.getShortDescription().replaceAll("\"", "\\\"") %>"
             )
 <%          if ((availableAgentSelectors.size() - i) > 1) { %>
                 ,

--- a/src/web/interceptors.jsp
+++ b/src/web/interceptors.jsp
@@ -192,7 +192,7 @@
     }
 
     private String escapeHTML(String html) {
-        html = StringUtils.replace(html, "\"", "&quot;");
+        html = html.replaceAll("\"", "&quot;");
         return StringUtils.escapeHTMLTags(html);
     }
 %>
@@ -598,7 +598,7 @@ var routerInfo = new Array(
         "<%= descriptor.getBeanClass().getName() %>",
         "<%= descriptor.getValue("version") %>",
         "<%= descriptor.getValue("author") %>",
-        "<%= StringUtils.replace(descriptor.getShortDescription(), "\"", "\\\"") %>"
+        "<%= descriptor.getShortDescription().replaceAll("\"", "\\\"") %>"
     )
 <%          if ((interceptorManager.getAvailableInterceptors().size() - i) > 1) { %>
         ,


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0, but also API usage that was removed earlier (4.5, 4.6?)

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #68