### PR TITLE
fixes #59: Additional permissions for XStream

### DIFF
--- a/src/java/org/jivesoftware/openfire/fastpath/macros/MacroProvider.java
+++ b/src/java/org/jivesoftware/openfire/fastpath/macros/MacroProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,11 @@ public class MacroProvider implements WorkgroupProvider {
 
             DbProperties props = agent.getProperties();
             XStream xstream = new XStream();
+            xstream.setClassLoader(this.getClass().getClassLoader());
+            xstream.allowTypes(new Class[] {
+                Macro.class,
+                MacroGroup.class
+            });
             xstream.alias("macro", Macro.class);
             xstream.alias("macrogroup", MacroGroup.class);
             MacroGroup group = (MacroGroup)xstream.fromXML(personalMacro);

--- a/src/java/org/jivesoftware/openfire/fastpath/macros/WorkgroupMacros.java
+++ b/src/java/org/jivesoftware/openfire/fastpath/macros/WorkgroupMacros.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class WorkgroupMacros {
     private static WorkgroupMacros singleton;
 
     private static final Object LOCK = new Object();
-    private XStream xstream = new XStream();
+    private final XStream xstream;
 
     /**
      * Returns the singleton instance of <CODE>WorkgroupMacros</CODE>,
@@ -63,9 +63,16 @@ public class WorkgroupMacros {
     private WorkgroupMacros() {
         // Load macros
         WorkgroupManager workgroupManager = WorkgroupManager.getInstance();
+
+        xstream = new XStream();
+        XStream xstream = new XStream();
+        xstream.setClassLoader(this.getClass().getClassLoader());
+        xstream.allowTypes(new Class[] {
+            Macro.class,
+            MacroGroup.class
+        });
         xstream.alias("macro", Macro.class);
         xstream.alias("macrogroup", MacroGroup.class);
-
 
         for (Workgroup workgroup : workgroupManager.getWorkgroups()) {
             // Load from DB.

--- a/src/java/org/jivesoftware/openfire/fastpath/settings/chat/ChatSettingsCreator.java
+++ b/src/java/org/jivesoftware/openfire/fastpath/settings/chat/ChatSettingsCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1999-2008 Jive Software. All rights reserved.
+ * Copyright (C) 1999-2008 Jive Software, 2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,6 @@ import org.jivesoftware.xmpp.workgroup.utils.ModelUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
-
-import com.thoughtworks.xstream.XStream;
 
 /**
  * Creates the default settings for the Web Chat UI. This includes the Web Chat UI
@@ -395,11 +393,6 @@ public class ChatSettingsCreator {
      * @param workgroupJID the full-jid of the workgroup.
      */
     public void createDefaultSettings(JID workgroupJID) {
-        final XStream xstream = new XStream();
-        xstream.alias("ChatSettings", ChatSettings.class);
-        xstream.alias("Key", KeyEnum.class);
-        xstream.alias("Setting", ChatSetting.class);
-
         createImageSettings(workgroupJID);
         createTextSettings(workgroupJID);
         createBotSettings(workgroupJID);


### PR DESCRIPTION
In a later version of XStream, explicit permission needs to be given for classes to be (de)serialized as XML.

As in older versions, these permissions were not needed, they're absent in the code.

This commit adds those permissions, building on an earlier commit that introduced the first few permissions.