### PR TITLE
Send the correct reason when offer is canceled or a timeout occurs

### DIFF
--- a/src/java/org/jivesoftware/xmpp/workgroup/Offer.java
+++ b/src/java/org/jivesoftware/xmpp/workgroup/Offer.java
@@ -221,7 +221,7 @@ public class Offer {
         Log.debug("Accepted or not: send a revocation to all pending sessions.");
         try {
             for (AgentSession session : pendingSessions) {
-                request.sendRevoke(session, queue);
+                request.sendRevoke(session, queue, "The offer has timed out");
 
                 if (!isAccepted()) {
                     Log.debug("Not accepted. Rejecting...");
@@ -240,10 +240,10 @@ public class Offer {
         // Handle when customer cancels.
         if (!pendingSessions.isEmpty() || !acceptedSessions.isEmpty()) {
             for (AgentSession session : pendingSessions) {
-                request.sendRevoke(session, queue);
+                request.sendRevoke(session, queue, "User canceled");
             }
             for (AgentSession session : acceptedSessions) {
-                request.sendRevoke(session, queue);
+                request.sendRevoke(session, queue, "User canceled");
             }
             pendingSessions.clear();
             acceptedSessions.clear();

--- a/src/java/org/jivesoftware/xmpp/workgroup/dispatcher/OpportunisticDispatcher.java
+++ b/src/java/org/jivesoftware/xmpp/workgroup/dispatcher/OpportunisticDispatcher.java
@@ -82,7 +82,7 @@ public class OpportunisticDispatcher extends AbstractDispatcher
             // Create the room and send the invitations
             offer.invite(selectedAgent);
 
-            // Notify the other agents tat accepted that the offer process has finished. Other pending sessions will
+            // Notify the other agents that accepted that the offer process has finished. Other pending sessions will
             // already have been notified.
             for (AgentSession offeredAgent : offeredAgents) {
                 offeredAgent.removeOffer(offer);
@@ -90,7 +90,7 @@ public class OpportunisticDispatcher extends AbstractDispatcher
                     continue;
                 }
                 Log.debug("Offer for request: {} REVOKING from agent that was also offered this request: {}", offer.getRequest(), offeredAgent.getJID());
-                offer.getRequest().sendRevoke(offeredAgent, queue);
+                offer.getRequest().sendRevoke(offeredAgent, queue, "The offer has timed out");
             }
 
             if (offer.getRequest() instanceof UserRequest) {

--- a/src/java/org/jivesoftware/xmpp/workgroup/request/Request.java
+++ b/src/java/org/jivesoftware/xmpp/workgroup/request/Request.java
@@ -254,7 +254,7 @@ public abstract class Request {
      * @param session the agent session that will get the revoke.
      * @param queue queue that is sending the offer.
      */
-    public void sendRevoke(AgentSession session, RequestQueue queue) {
+    public void sendRevoke(AgentSession session, RequestQueue queue, String reason) {
         IQ agentRevoke = new IQ();
         agentRevoke.setFrom(queue.getWorkgroup().getJID());
         agentRevoke.setTo(session.getJID());
@@ -263,7 +263,7 @@ public abstract class Request {
         Element revoke = agentRevoke.setChildElement("offer-revoke", "http://jabber.org/protocol/workgroup");
         revoke.addAttribute("id", requestID);
         revoke.addAttribute("jid", getUserJID().toString());
-        revoke.addElement("reason").setText("The offer has timed out");
+        revoke.addElement("reason").setText(reason);
         revoke.add(getSessionElement());
         addRevokeContent(revoke);
 


### PR DESCRIPTION
The intention of this patch is to enable clients to distinguish whether an offer was canceled by the user or if a timeout occurred. Currently, 'The offer has timed out' is sent in both cases.